### PR TITLE
 [Docs] Transition API : Update link to example app

### DIFF
--- a/pages/04.transitions.md
+++ b/pages/04.transitions.md
@@ -58,4 +58,4 @@ Use `Transition.Change` component to specify how components' which properties ge
 
 ## How to use it
 
-This API is still experimental and is a subject to change. Please refer to our [Example app](https://github.com/software-mansion/react-native-reanimated/tree/master/Example/src/transitions) to see how it can be used in practice in the current shape.
+This API is still experimental and is a subject to change. Please refer to our [Example app](https://github.com/software-mansion/react-native-reanimated/tree/master/Example/reanimated1/transitions) to see how it can be used in practice in the current shape.


### PR DESCRIPTION
Previous link to example app is broken. Replaced with new one